### PR TITLE
FIX Reduce warning to debug log level to prevent CLI error handler catching messages

### DIFF
--- a/src/Services/LDAPService.php
+++ b/src/Services/LDAPService.php
@@ -507,14 +507,14 @@ class LDAPService implements Flushable
         }
 
         if (!$member->GUID) {
-            $this->getLogger()->warning(sprintf('Cannot update Member ID %s, GUID not set', $member->ID));
+            $this->getLogger()->debug(sprintf('Cannot update Member ID %s, GUID not set', $member->ID));
             return false;
         }
 
         if (!$data) {
             $data = $this->getUserByGUID($member->GUID);
             if (!$data) {
-                $this->getLogger()->warning(sprintf('Could not retrieve data for user. GUID: %s', $member->GUID));
+                $this->getLogger()->debug(sprintf('Could not retrieve data for user. GUID: %s', $member->GUID));
                 return false;
             }
         }
@@ -542,7 +542,7 @@ class LDAPService implements Flushable
                 if ($imageClass !== Image::class
                     && !is_subclass_of($imageClass, Image::class)
                 ) {
-                    $this->getLogger()->warning(
+                    $this->getLogger()->debug(
                         sprintf(
                             'Member field %s configured for thumbnailphoto AD attribute, but it isn\'t a ' .
                             'valid relation to an Image class',
@@ -584,7 +584,7 @@ class LDAPService implements Flushable
         if ($this->config()->default_group) {
             $group = Group::get()->filter('Code', $this->config()->default_group)->limit(1)->first();
             if (!($group && $group->exists())) {
-                $this->getLogger()->warning(
+                $this->getLogger()->debug(
                     sprintf(
                         'LDAPService.default_group misconfiguration! There is no such group with Code = \'%s\'',
                         $this->config()->default_group
@@ -632,7 +632,7 @@ class LDAPService implements Flushable
             foreach ($ldapGroups as $groupDN) {
                 foreach (LDAPGroupMapping::get() as $mapping) {
                     if (!$mapping->DN) {
-                        $this->getLogger()->warning(
+                        $this->getLogger()->debug(
                             sprintf(
                                 'LDAPGroupMapping ID %s is missing DN field. Skipping',
                                 $mapping->ID
@@ -1042,7 +1042,7 @@ class LDAPService implements Flushable
         $this->extend('onBeforeSetPassword', $member, $password, $validationResult);
 
         if (!$member->GUID) {
-            $this->getLogger()->warning(sprintf('Cannot update Member ID %s, GUID not set', $member->ID));
+            $this->getLogger()->debug(sprintf('Cannot update Member ID %s, GUID not set', $member->ID));
             $validationResult->addError(
                 _t(
                     'SilverStripe\\LDAP\\Authenticators\\LDAPAuthenticator.NOUSER',


### PR DESCRIPTION
Reducing the log level to ensure that CLI error handler doesn't throw these to the console, for example while running unit tests. Related: https://github.com/silverstripe/silverstripe-framework/issues/8044