### PR TITLE
FIX Username field is always inserted before the email field

### DIFF
--- a/src/Extensions/LDAPMemberExtension.php
+++ b/src/Extensions/LDAPMemberExtension.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\LDAP\Extensions;
 
 use Exception;
+use SilverStripe\Forms\TextField;
 use SilverStripe\LDAP\Services\LDAPService;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\FieldList;
@@ -153,6 +154,13 @@ class LDAPMemberExtension extends DataExtension
                 'FirstName'
             );
         }
+
+        // Ensure blog fields are added after first and last name
+        $fields->addFieldToTab(
+            'Root.Main',
+            TextField::create('Username'),
+            'Email'
+        );
     }
 
     /**


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-blog/issues/551 for the example issue

I think it makes sense to put the username field before the email field, because that's usually where you'd find a username field.

![image](https://user-images.githubusercontent.com/5170590/45094705-4e8f1280-b11c-11e8-99cf-04f413e25108.png)
