### PR TITLE
FIX Use stable releases of CMS 4.2 for Travis tests, fix coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DB=MYSQL RECIPE_VERSION=4.2.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.2.* PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.0
-      env: DB=PGSQL RECIPE_VERSION=4.2.x-dev PHPUNIT_TEST=1
+      env: DB=PGSQL RECIPE_VERSION=4.2.* PHPUNIT_TEST=1
     - php: 7.1
       env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_COVERAGE_TEST=1
     - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: php
 
+dist: xenial
+
+services:
+  - mysql
+  - postgresql
+
 env:
   global:
     - COMPOSER_ROOT_VERSION="1.x-dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - phpenv config-rm xdebug.ini
 
   - composer require --no-update silverstripe/recipe-cms:"$RECIPE_VERSION"
-  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:2.0.x-dev; fi
+  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:^2; fi
   - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:


### PR DESCRIPTION
The core 4.2 branches no longer exist, so to test them we need to target tagged releases from now on.