### PR TITLE
FIX Use injectable version of queuedjobs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.4 || ^8.0",
         "silverstripe/framework": "^4.10",
         "silverstripe/cms": "^4.1",
-        "symbiote/silverstripe-queuedjobs": "^4",
+        "symbiote/silverstripe-queuedjobs": "^4.1",
         "zendframework/zend-ldap": "^2.5.1",
         "zendframework/zend-authentication": "^2.5.1",
         "zendframework/zend-session": "^2.5.1"


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Match 1.4 branch - looks like this was missed including on the merge-up

Fix https://github.com/silverstripe/silverstripe-ldap/runs/7490658811?check_suite_focus=true#step:10:688
`Call to undefined method Symbiote\QueuedJobs\Services\QueuedJobService::singleton()`