### PR TITLE
FIX Remove call to deprecated constructExtensions method

### DIFF
--- a/src/Services/LDAPService.php
+++ b/src/Services/LDAPService.php
@@ -143,11 +143,6 @@ class LDAPService implements Flushable
      */
     public $gateway;
 
-    public function __construct()
-    {
-        $this->constructExtensions();
-    }
-
     /**
      * Setter for gateway. Useful for overriding the gateway with a fake for testing.
      * @var LDAPGateway


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-framework/issues/10389