### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "4.13.x-dev",
-        "silverstripe/cms": "4.13.x-dev",
-        "symbiote/silverstripe-queuedjobs": "4.12.x-dev",
+        "silverstripe/framework": "^4.10",
+        "silverstripe/cms": "^4.1",
+        "symbiote/silverstripe-queuedjobs": "^4.1",
         "zendframework/zend-ldap": "^2.5.1",
         "zendframework/zend-authentication": "^2.5.1",
         "zendframework/zend-session": "^2.5.1"


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33