### PR TITLE
DEP Bump minimum version of framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4.11",
         "silverstripe/cms": "^4.1",
         "symbiote/silverstripe-queuedjobs": "^4.1",
         "zendframework/zend-ldap": "^2.5.1",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Fixes an issue with egulias/email-validator on --prefer-lowest build

https://github.com/silverstripe/silverstripe-ldap/actions/runs/9851670638/job/27198912110