### PR TITLE
ENH Add nested groups search locations and user filter

### DIFF
--- a/src/Model/LDAPGateway.php
+++ b/src/Model/LDAPGateway.php
@@ -35,6 +35,14 @@ class LDAPGateway
     private static $options = [];
 
     /**
+     * If configured, only user objects matching this LDAP filter will be considered to this service instead of the default.
+     * @var string
+     *
+     * @config
+     */
+    private static $user_filter = [];
+
+    /**
      * @var Laminas\Ldap\Ldap
      */
     private $ldap;
@@ -256,7 +264,7 @@ class LDAPGateway
      */
     public function getUsers($baseDn = null, $scope = Ldap::SEARCH_SCOPE_SUB, $attributes = [], $sort = '')
     {
-        $filter = '(&(objectClass=user)(!(objectClass=computer))(!(samaccountname=Guest))(!(samaccountname=Administrator))(!(samaccountname=krbtgt)))';
+        $filter = $this->config()->user_filter ?: '(&(objectClass=user)(!(objectClass=computer))(!(samaccountname=Guest))(!(samaccountname=Administrator))(!(samaccountname=krbtgt)))';
 
         $this->extend('updateUsersFilter', $filter);
 
@@ -279,7 +287,7 @@ class LDAPGateway
      */
     public function getUsersWithIterator($baseDn = null, $attributes = [])
     {
-        $filter = '(&(objectClass=user)(!(objectClass=computer))(!(samaccountname=Guest))(!(samaccountname=Administrator))(!(samaccountname=krbtgt)))';
+        $filter = $this->config()->user_filter ?: '(&(objectClass=user)(!(objectClass=computer))(!(samaccountname=Guest))(!(samaccountname=Administrator))(!(samaccountname=krbtgt)))';
 
         $this->extend('updateUsersWithIteratorFilter', $filter);
 

--- a/src/Services/LDAPService.php
+++ b/src/Services/LDAPService.php
@@ -69,6 +69,14 @@ class LDAPService implements Flushable
     private static $groups_search_locations = [];
 
     /**
+     * If configured, only group objects within these locations will be searched for nexted groups to this service.
+     * @var array
+     *
+     * @config
+     */
+    private static $nested_groups_search_locations = [];
+
+    /**
      * Location to create new users in (distinguished name).
      * @var string
      *
@@ -301,7 +309,7 @@ class LDAPService implements Flushable
             return LDAPService::$_cache_nested_groups[$dn];
         }
 
-        $searchLocations = $this->config()->groups_search_locations ?: [null];
+        $searchLocations = $this->config()->nested_groups_search_locations ?: $this->config()->groups_search_locations ?: [null];
         $results = [];
         foreach ($searchLocations as $searchLocation) {
             $records = $this->getGateway()->getNestedGroups($dn, $searchLocation, Ldap::SEARCH_SCOPE_SUB, $attributes);

--- a/src/Services/LDAPService.php
+++ b/src/Services/LDAPService.php
@@ -69,7 +69,9 @@ class LDAPService implements Flushable
     private static $groups_search_locations = [];
 
     /**
-     * If configured, only group objects within these locations will be searched for nexted groups to this service.
+     * If configured, only group objects within these locations will be searched for nested groups to this service.
+     * This allows the configuration to include nested groups from other LDAP locations -- outside of the group search
+     * locations.
      * @var array
      *
      * @config


### PR DESCRIPTION
## Description
Introduce a couple of configuration options:
* user filter -- allows configuration to override the built-in filter to e.g. limit users to members of a specific group
* nested group search location -- allows configuration to consider nested groups in different location than the primary group search location.

## Manual testing steps
If neither option is configured no change in the behavior.
The system behavior reflects the configuration in either setting.

## Issues
- #100 

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
